### PR TITLE
neovim 0.12 updates + shared, persistent info panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ require'coq-lsp'.setup {
   -- The configuration for coq-lsp.nvim.
   -- The following is the default configuration.
   coq_lsp_nvim = {
-    -- to be added
+    --   "tab"    = one shared panel per tab, tracks the focused coq buffer.
+    --   "buffer" = one panel per coq buffer.
+    info_panel_mode = 'tab',
   },
 
   -- The configuration forwarded to `:help lspconfig-setup`.

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -2,9 +2,9 @@ local util = require('coq-lsp.util')
 local render = require('coq-lsp.render')
 
 ---@class CoqLSPNvim
----@field lc lsp.Client
+---@field lc vim.lsp.Client
 ---@field buffers table<buffer, { info_bufnr: buffer, cancel_goals?: fun() }>
----@field debounce_timer uv_timer_t
+---@field debounce_timer uv.uv_timer_t
 ---@field config coqlsp.config
 ---@field progress_ns integer
 ---@field ag integer
@@ -14,13 +14,13 @@ CoqLSPNvim.__index = CoqLSPNvim
 ---@type string[] command names
 local commands = {}
 
----@param client lsp.Client
+---@param client vim.lsp.Client
 ---@param config coqlsp.config
 function CoqLSPNvim:new(client, config)
   local new = {}
   new.lc = client
   new.buffers = {}
-  new.debounce_timer = assert(vim.loop.new_timer(), 'Could not create timer')
+  new.debounce_timer = assert(vim.uv.new_timer(), 'Could not create timer')
   new.config = config
   new.progress_ns = vim.api.nvim_create_namespace('coq-lsp-progress-' .. client.id)
   new.ag = vim.api.nvim_create_augroup('coq-lsp-' .. client.id, { clear = true })
@@ -44,13 +44,13 @@ function CoqLSPNvim:fileProgress(result)
   -- TODO: Highlight is very noisy when typing. Use sign or something else.
   for _, info in ipairs(result.processing) do
     local kind = info.kind or CoqFileProgressKind.Processing
-    vim.highlight.range(
+    vim.hl.range(
       bufnr,
       self.progress_ns,
       progress_highlight_kind[kind],
       util.position_lsp_to_api(bufnr, info.range['start'], self.lc.offset_encoding),
       util.position_lsp_to_api(bufnr, info.range['end'], self.lc.offset_encoding),
-      { priority = vim.highlight.priorities.user }
+      { priority = vim.hl.priorities.user }
     )
   end
 end
@@ -159,7 +159,7 @@ function CoqLSPNvim:goals_sync(bufnr, position)
     textDocument = vim.lsp.util.make_text_document_params(bufnr),
     position = util.make_position_params(bufnr, position, self.lc.offset_encoding),
   }
-  local request_result, err = self.lc.request_sync('proof/goals', params, 500, bufnr)
+  local request_result, err = self.lc:request_sync('proof/goals', params, 500, bufnr)
   if err then
     vim.notify('goals_sync() failed: ' .. err, vim.log.levels.ERROR)
     return
@@ -177,7 +177,7 @@ function CoqLSPNvim:get_document(bufnr)
   local params = {
     textDocument = vim.lsp.util.make_text_document_params(bufnr),
   }
-  local request_result, err = self.lc.request_sync('coq/getDocument', params, 500, bufnr)
+  local request_result, err = self.lc:request_sync('coq/getDocument', params, 500, bufnr)
   if err then
     vim.notify('get_document() failed: ' .. err, vim.log.levels.ERROR)
     return
@@ -195,7 +195,7 @@ function CoqLSPNvim:saveVo(bufnr)
   local params = {
     textDocument = vim.lsp.util.make_text_document_params(bufnr),
   }
-  local request_result, err = self.lc.request_sync('coq/saveVo', params, 500, bufnr)
+  local request_result, err = self.lc:request_sync('coq/saveVo', params, 500, bufnr)
   if err then
     vim.notify('saveVo() failed: ' .. err, vim.log.levels.ERROR)
     return

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -308,7 +308,9 @@ function CoqLSPNvim:register(bufnr)
     end,
   })
 
-  self:goals_async(bufnr)
+  if vim.api.nvim_get_current_buf() == bufnr then
+    self:goals_async(bufnr)
+  end
 end
 
 ---@param args string

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -56,9 +56,16 @@ function CoqLSPNvim:fileProgress(result)
   end
 end
 
+---@param bufnr buffer
+---@return coqlsp.PanelKey
+function CoqLSPNvim:panel_key(bufnr)
+  return self.config.info_panel_mode == 'buffer' and bufnr or vim.api.nvim_get_current_tabpage()
+end
+
 ---@param bufnr? buffer
 function CoqLSPNvim:open_info_panel(bufnr)
-  panel.open(bufnr or vim.api.nvim_get_current_buf())
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  panel.open(self:panel_key(bufnr), bufnr)
 end
 commands[#commands + 1] = 'open_info_panel'
 
@@ -182,7 +189,7 @@ end
 function CoqLSPNvim:register(bufnr)
   assert(self.buffers[bufnr] == nil)
   self.buffers[bufnr] = {}
-  panel.open(bufnr)
+  panel.open(self:panel_key(bufnr), bufnr)
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = self.ag,
@@ -197,7 +204,7 @@ function CoqLSPNvim:register(bufnr)
     buffer = bufnr,
     desc = 'Retarget info panel to focused coq buffer',
     callback = function(ev)
-      panel.retarget(ev.buf)
+      panel.retarget(self:panel_key(ev.buf), ev.buf)
     end,
   })
   vim.api.nvim_create_autocmd('LspDetach', {

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -4,6 +4,7 @@ local render = require('coq-lsp.render')
 ---@class CoqLSPNvim
 ---@field lc vim.lsp.Client
 ---@field buffers table<buffer, { info_bufnr: buffer, cancel_goals?: fun() }>
+---@field panel_wins table<integer, window> tabpage -> info panel window
 ---@field debounce_timer uv.uv_timer_t
 ---@field config coqlsp.config
 ---@field progress_ns integer
@@ -20,6 +21,7 @@ function CoqLSPNvim:new(client, config)
   local new = {}
   new.lc = client
   new.buffers = {}
+  new.panel_wins = {}
   new.debounce_timer = assert(vim.uv.new_timer(), 'Could not create timer')
   new.config = config
   new.progress_ns = vim.api.nvim_create_namespace('coq-lsp-progress-' .. client.id)
@@ -75,18 +77,55 @@ end
 ---@param bufnr? buffer
 function CoqLSPNvim:open_info_panel(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local info_bufnr = self:get_info_bufnr(bufnr)
+  local tab = vim.api.nvim_get_current_tabpage()
+
+  local existing = self.panel_wins[tab]
+  if existing and vim.api.nvim_win_is_valid(existing) then
+    vim.api.nvim_win_set_buf(existing, info_bufnr)
+    return
+  end
+
   local win = vim.api.nvim_get_current_win()
   vim.cmd.sbuffer {
-    args = { self:get_info_bufnr(bufnr) },
+    args = { info_bufnr },
     -- TODO: customization
     -- See `:h nvim_parse_cmd`. Note that the "split size" is `range`.
     mods = { keepjumps = true, keepalt = true, vertical = true, split = 'belowright' },
   }
   vim.cmd.clearjumps()
+  local panel_win = vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(win)
+
+  self.panel_wins[tab] = panel_win
+  vim.api.nvim_create_autocmd('WinClosed', {
+    group = self.ag,
+    pattern = tostring(panel_win),
+    once = true,
+    desc = 'Forget closed info panel window',
+    callback = function()
+      self.panel_wins[tab] = nil
+    end,
+  })
 end
 
 commands[#commands + 1] = 'open_info_panel'
+
+---Retarget the current tab's info panel to the current coq buffer, if any.
+---No-op when the tab has no panel (respects manual close) or the current
+---buffer isn't a registered coq buffer.
+function CoqLSPNvim:retarget_panel()
+  local bufnr = vim.api.nvim_get_current_buf()
+  if not self.buffers[bufnr] then
+    return
+  end
+  local tab = vim.api.nvim_get_current_tabpage()
+  local panel_win = self.panel_wins[tab]
+  if not (panel_win and vim.api.nvim_win_is_valid(panel_win)) then
+    return
+  end
+  vim.api.nvim_win_set_buf(panel_win, self:get_info_bufnr(bufnr))
+end
 
 ---@param answer coqlsp.GoalAnswer
 ---@param position MarkPosition Don't use answer.position because buffer content may have changed.
@@ -236,6 +275,14 @@ function CoqLSPNvim:register(bufnr)
     desc = 'Request proof/goals on cursor movement',
     callback = function()
       self:goals_async_debounced()
+    end,
+  })
+  vim.api.nvim_create_autocmd('BufEnter', {
+    group = self.ag,
+    buffer = bufnr,
+    desc = 'Retarget info panel to focused coq buffer',
+    callback = function()
+      self:retarget_panel()
     end,
   })
   -- nvim bug? If the current coq buf is the only valid buffer and I bwipeout

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -1,10 +1,10 @@
 local util = require('coq-lsp.util')
 local render = require('coq-lsp.render')
+local panel = require('coq-lsp.panel')
 
 ---@class CoqLSPNvim
 ---@field lc vim.lsp.Client
----@field buffers table<buffer, { info_bufnr: buffer, cancel_goals?: fun() }>
----@field panel_wins table<integer, window> tabpage -> info panel window
+---@field buffers table<buffer, { cancel_goals?: fun() }>
 ---@field debounce_timer uv.uv_timer_t
 ---@field config coqlsp.config
 ---@field progress_ns integer
@@ -21,7 +21,6 @@ function CoqLSPNvim:new(client, config)
   local new = {}
   new.lc = client
   new.buffers = {}
-  new.panel_wins = {}
   new.debounce_timer = assert(vim.uv.new_timer(), 'Could not create timer')
   new.config = config
   new.progress_ns = vim.api.nvim_create_namespace('coq-lsp-progress-' .. client.id)
@@ -57,97 +56,17 @@ function CoqLSPNvim:fileProgress(result)
   end
 end
 
----@param bufnr buffer
-function CoqLSPNvim:create_info_panel(bufnr)
-  local info_bufnr = vim.api.nvim_create_buf(false, true)
-  vim.bo[info_bufnr].filetype = 'coq-goals'
-  self.buffers[bufnr].info_bufnr = info_bufnr
-end
-
----@param bufnr buffer
-function CoqLSPNvim:get_info_bufnr(bufnr)
-  local info_bufnr = self.buffers[bufnr].info_bufnr
-  if info_bufnr and vim.api.nvim_buf_is_valid(info_bufnr) then
-    return info_bufnr
-  end
-  self:create_info_panel(bufnr)
-  return self.buffers[bufnr].info_bufnr
-end
-
 ---@param bufnr? buffer
 function CoqLSPNvim:open_info_panel(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-  local info_bufnr = self:get_info_bufnr(bufnr)
-  local tab = vim.api.nvim_get_current_tabpage()
-
-  local existing = self.panel_wins[tab]
-  if existing and vim.api.nvim_win_is_valid(existing) then
-    vim.api.nvim_win_set_buf(existing, info_bufnr)
-    return
-  end
-
-  local win = vim.api.nvim_get_current_win()
-  vim.cmd.sbuffer {
-    args = { info_bufnr },
-    -- TODO: customization
-    -- See `:h nvim_parse_cmd`. Note that the "split size" is `range`.
-    mods = { keepjumps = true, keepalt = true, vertical = true, split = 'belowright' },
-  }
-  vim.cmd.clearjumps()
-  local panel_win = vim.api.nvim_get_current_win()
-  vim.api.nvim_set_current_win(win)
-
-  self.panel_wins[tab] = panel_win
-  vim.api.nvim_create_autocmd('WinClosed', {
-    group = self.ag,
-    pattern = tostring(panel_win),
-    once = true,
-    desc = 'Forget closed info panel window',
-    callback = function()
-      self.panel_wins[tab] = nil
-    end,
-  })
+  panel.open(bufnr or vim.api.nvim_get_current_buf())
 end
-
 commands[#commands + 1] = 'open_info_panel'
-
----Retarget the current tab's info panel to the current coq buffer, if any.
----No-op when the tab has no panel (respects manual close) or the current
----buffer isn't a registered coq buffer.
-function CoqLSPNvim:retarget_panel()
-  local bufnr = vim.api.nvim_get_current_buf()
-  if not self.buffers[bufnr] then
-    return
-  end
-  local tab = vim.api.nvim_get_current_tabpage()
-  local panel_win = self.panel_wins[tab]
-  if not (panel_win and vim.api.nvim_win_is_valid(panel_win)) then
-    return
-  end
-  vim.api.nvim_win_set_buf(panel_win, self:get_info_bufnr(bufnr))
-end
 
 ---@param answer coqlsp.GoalAnswer
 ---@param position MarkPosition Don't use answer.position because buffer content may have changed.
 function CoqLSPNvim:show_goals(answer, position)
   local bufnr = vim.uri_to_bufnr(answer.textDocument.uri)
-  local info_bufnr = self:get_info_bufnr(bufnr)
-
-  local wins = {} ---@type table<window, vim.fn.winsaveview.ret>
-  for _, win in ipairs(vim.fn.win_findbuf(info_bufnr) or {}) do
-    vim.api.nvim_win_call(win, function()
-      wins[win] = vim.fn.winsaveview()
-    end)
-  end
-
-  local lines = render.GoalAnswer(answer, position)
-  vim.api.nvim_buf_set_lines(info_bufnr, 0, -1, false, lines)
-
-  for win, view in pairs(wins) do
-    vim.api.nvim_win_call(win, function()
-      vim.fn.winrestview(view)
-    end)
-  end
+  panel.render(bufnr, render.GoalAnswer(answer, position))
 end
 
 ---@param bufnr? buffer registered buffer
@@ -256,9 +175,6 @@ function CoqLSPNvim:unregister(bufnr)
   assert(self.buffers[bufnr])
   vim.api.nvim_buf_clear_namespace(bufnr, self.progress_ns, 0, -1)
   vim.api.nvim_clear_autocmds { group = self.ag, buffer = bufnr }
-  if self.buffers[bufnr].info_bufnr then
-    vim.api.nvim_buf_delete(self.buffers[bufnr].info_bufnr, { force = true })
-  end
   self.buffers[bufnr] = nil
 end
 
@@ -266,8 +182,7 @@ end
 function CoqLSPNvim:register(bufnr)
   assert(self.buffers[bufnr] == nil)
   self.buffers[bufnr] = {}
-  self:create_info_panel(bufnr)
-  self:open_info_panel(bufnr)
+  panel.open(bufnr)
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = self.ag,
@@ -281,18 +196,18 @@ function CoqLSPNvim:register(bufnr)
     group = self.ag,
     buffer = bufnr,
     desc = 'Retarget info panel to focused coq buffer',
-    callback = function()
-      self:retarget_panel()
+    callback = function(ev)
+      panel.retarget(ev.buf)
     end,
   })
-  -- nvim bug? If the current coq buf is the only valid buffer and I bwipeout
-  -- that buffer, this buffer is newly added to buffer list.
-  vim.api.nvim_create_autocmd({ 'BufDelete', 'LspDetach' }, {
+  vim.api.nvim_create_autocmd('LspDetach', {
     group = self.ag,
     buffer = bufnr,
-    desc = 'Unregister deleted/detached buffer',
+    desc = 'Unregister detached buffer',
     callback = function(ev)
-      self:unregister(ev.buf)
+      if self.buffers[ev.buf] then
+        self:unregister(ev.buf)
+      end
     end,
   })
 

--- a/lua/coq-lsp/init.lua
+++ b/lua/coq-lsp/init.lua
@@ -29,8 +29,8 @@ local function make_on_init(user_on_init)
   end
 end
 
----@param user_on_attach? fun(client: lsp.Client, bufnr: buffer)
----@return fun(client: lsp.Client, bufnr: buffer)
+---@param user_on_attach? fun(client: vim.lsp.Client, bufnr: buffer)
+---@return fun(client: vim.lsp.Client, bufnr: buffer)
 local function make_on_attach(user_on_attach)
   return function(client, bufnr)
     if not M.clients[client.id].buffers[bufnr] then
@@ -74,20 +74,13 @@ function M.setup(opts)
   local user_on_exit = opts.lsp.on_exit
   opts.lsp.on_exit = make_on_exit(user_on_exit)
 
-  if vim.fn.has('nvim-0.11') == 1 then
-    -- Use native LSP setup for Neovim 0.11+
-    local config = {
-        cmd = { 'coq-lsp' },
-        filetypes = { 'coq' },
-        root_markers = { '_CoqProject', '.git' },
-    }
-
-    vim.lsp.config('coq_lsp', vim.tbl_deep_extend('force', config, opts.lsp))
-    vim.lsp.enable('coq_lsp')
-  else
-    -- Fallback to lspconfig for older versions
-    require('lspconfig').coq_lsp.setup(opts.lsp)
-  end
+  local config = {
+    cmd = { 'coq-lsp' },
+    filetypes = { 'coq' },
+    root_markers = { '_CoqProject', '.git' },
+  }
+  vim.lsp.config('coq_lsp', vim.tbl_deep_extend('force', config, opts.lsp))
+  vim.lsp.enable('coq_lsp')
 end
 
 return M

--- a/lua/coq-lsp/init.lua
+++ b/lua/coq-lsp/init.lua
@@ -3,13 +3,14 @@ local M = {}
 ---@class coqlsp.config
 ---@field goals_debounce integer
 ---@field show_goals_on "manual"|"cursor"
+---@field info_panel_mode "tab"|"buffer"
 
 ---@type coqlsp.config
-local default_config = {
+M.config = {
   -- TODO: implement it; should be dynamically configurable
   show_goals_on = 'cursor',
   goals_debounce = 150,
-  -- TODO: info panel mode: global panel or one for each buffer
+  info_panel_mode = 'tab',
 }
 
 ---@type table<integer, CoqLSPNvim>
@@ -22,7 +23,7 @@ local function make_on_init(user_on_init)
       vim.print('[coq-lsp.nvim] on_init failed', CoqLSPNvim)
       return
     end
-    M.clients[client.id] = CoqLSPNvim:new(client, default_config)
+    M.clients[client.id] = CoqLSPNvim:new(client, M.config)
     if user_on_init then
       user_on_init(client, initialize_result)
     end
@@ -63,6 +64,7 @@ end
 ---@param opts { coq_lsp_nvim?: table<string,any>, lsp?: table<string,any> }
 function M.setup(opts)
   opts = opts or {}
+  M.config = vim.tbl_extend('force', M.config, opts.coq_lsp_nvim or {})
   opts.lsp = opts.lsp or {}
   opts.lsp.handlers = vim.tbl_extend('keep', opts.lsp.handlers or {}, {
     ['$/coq/fileProgress'] = fileProgress_notification_handler,
@@ -74,12 +76,12 @@ function M.setup(opts)
   local user_on_exit = opts.lsp.on_exit
   opts.lsp.on_exit = make_on_exit(user_on_exit)
 
-  local config = {
+  local lsp_defaults = {
     cmd = { 'coq-lsp' },
     filetypes = { 'coq' },
     root_markers = { '_CoqProject', '.git' },
   }
-  vim.lsp.config('coq_lsp', vim.tbl_deep_extend('force', config, opts.lsp))
+  vim.lsp.config('coq_lsp', vim.tbl_deep_extend('force', lsp_defaults, opts.lsp))
   vim.lsp.enable('coq_lsp')
 end
 

--- a/lua/coq-lsp/panel.lua
+++ b/lua/coq-lsp/panel.lua
@@ -1,8 +1,16 @@
 -- Info-panel window and info-buffer management.
+--
+-- A panel is a UI artifact tied to a coq buffer, not to an LSP client.
+--
+-- `panel_wins` is keyed by an opaque "panel key" chosen by the caller —
+-- typically a tabpage id (one panel per tab) or a coq bufnr (one panel per
+-- buffer). The panel module doesn't care which; it just maps key -> window.
 
 local M = {}
 
----@type table<integer, window> tabpage -> info panel window
+---@alias coqlsp.PanelKey integer
+
+---@type table<coqlsp.PanelKey, window>
 local panel_wins = {}
 ---@type table<buffer, buffer> coq bufnr -> info bufnr
 local info_bufnrs = {}
@@ -38,15 +46,14 @@ function M.render(bufnr, lines)
   end
 end
 
----Open (or retarget) the info panel in the current tab to show `bufnr`'s goals.
----If the current tab already has a panel, retarget it without creating a new split.
----@param bufnr? buffer coq buffer (defaults to current)
-function M.open(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+---Open (or retarget) the info panel for `key` to show `bufnr`'s goals.
+---If the key already has a valid panel window, retarget it without creating a new split.
+---@param key coqlsp.PanelKey caller-chosen scope (tabpage id or bufnr)
+---@param bufnr buffer coq buffer
+function M.open(key, bufnr)
   local info_bufnr = M.get_info_bufnr(bufnr)
-  local tab = vim.api.nvim_get_current_tabpage()
 
-  local existing = panel_wins[tab]
+  local existing = panel_wins[key]
   if existing and vim.api.nvim_win_is_valid(existing) then
     vim.api.nvim_win_set_buf(existing, info_bufnr)
     return
@@ -60,16 +67,16 @@ function M.open(bufnr)
     mods = { keepjumps = true, keepalt = true, vertical = true, split = 'belowright' },
   }
   vim.cmd.clearjumps()
-  panel_wins[tab] = vim.api.nvim_get_current_win()
+  panel_wins[key] = vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(cur_win)
 end
 
----Retarget the current tab's panel (if any) to `bufnr`'s info buffer.
----No-op if there is no panel in this tab (respects manual close).
+---Retarget `key`'s panel (if any) to `bufnr`'s info buffer.
+---No-op if the key has no valid panel (respects manual close).
+---@param key coqlsp.PanelKey
 ---@param bufnr buffer coq buffer
-function M.retarget(bufnr)
-  local tab = vim.api.nvim_get_current_tabpage()
-  local win = panel_wins[tab]
+function M.retarget(key, bufnr)
+  local win = panel_wins[key]
   if not (win and vim.api.nvim_win_is_valid(win)) then
     return
   end
@@ -83,9 +90,9 @@ vim.api.nvim_create_autocmd('WinClosed', {
   desc = 'Forget closed coq-lsp info panel windows',
   callback = function(ev)
     local closed = tonumber(ev.match)
-    for tab, win in pairs(panel_wins) do
+    for key, win in pairs(panel_wins) do
       if win == closed then
-        panel_wins[tab] = nil
+        panel_wins[key] = nil
       end
     end
   end,

--- a/lua/coq-lsp/panel.lua
+++ b/lua/coq-lsp/panel.lua
@@ -1,0 +1,108 @@
+-- Info-panel window and info-buffer management.
+
+local M = {}
+
+---@type table<integer, window> tabpage -> info panel window
+local panel_wins = {}
+---@type table<buffer, buffer> coq bufnr -> info bufnr
+local info_bufnrs = {}
+
+---@param bufnr buffer coq buffer
+---@return buffer info bufnr (created lazily)
+function M.get_info_bufnr(bufnr)
+  local info = info_bufnrs[bufnr]
+  if info and vim.api.nvim_buf_is_valid(info) then
+    return info
+  end
+  info = vim.api.nvim_create_buf(false, true)
+  vim.bo[info].filetype = 'coq-goals'
+  info_bufnrs[bufnr] = info
+  return info
+end
+
+---@param bufnr buffer coq buffer
+---@param lines string[]
+function M.render(bufnr, lines)
+  local info_bufnr = M.get_info_bufnr(bufnr)
+  local views = {} ---@type table<window, vim.fn.winsaveview.ret>
+  for _, win in ipairs(vim.fn.win_findbuf(info_bufnr) or {}) do
+    vim.api.nvim_win_call(win, function()
+      views[win] = vim.fn.winsaveview()
+    end)
+  end
+  vim.api.nvim_buf_set_lines(info_bufnr, 0, -1, false, lines)
+  for win, view in pairs(views) do
+    vim.api.nvim_win_call(win, function()
+      vim.fn.winrestview(view)
+    end)
+  end
+end
+
+---Open (or retarget) the info panel in the current tab to show `bufnr`'s goals.
+---If the current tab already has a panel, retarget it without creating a new split.
+---@param bufnr? buffer coq buffer (defaults to current)
+function M.open(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local info_bufnr = M.get_info_bufnr(bufnr)
+  local tab = vim.api.nvim_get_current_tabpage()
+
+  local existing = panel_wins[tab]
+  if existing and vim.api.nvim_win_is_valid(existing) then
+    vim.api.nvim_win_set_buf(existing, info_bufnr)
+    return
+  end
+
+  local cur_win = vim.api.nvim_get_current_win()
+  vim.cmd.sbuffer {
+    args = { info_bufnr },
+    -- TODO: customization
+    -- See `:h nvim_parse_cmd`. Note that the "split size" is `range`.
+    mods = { keepjumps = true, keepalt = true, vertical = true, split = 'belowright' },
+  }
+  vim.cmd.clearjumps()
+  panel_wins[tab] = vim.api.nvim_get_current_win()
+  vim.api.nvim_set_current_win(cur_win)
+end
+
+---Retarget the current tab's panel (if any) to `bufnr`'s info buffer.
+---No-op if there is no panel in this tab (respects manual close).
+---@param bufnr buffer coq buffer
+function M.retarget(bufnr)
+  local tab = vim.api.nvim_get_current_tabpage()
+  local win = panel_wins[tab]
+  if not (win and vim.api.nvim_win_is_valid(win)) then
+    return
+  end
+  vim.api.nvim_win_set_buf(win, M.get_info_bufnr(bufnr))
+end
+
+local ag = vim.api.nvim_create_augroup('coq-lsp-panel', { clear = true })
+
+vim.api.nvim_create_autocmd('WinClosed', {
+  group = ag,
+  desc = 'Forget closed coq-lsp info panel windows',
+  callback = function(ev)
+    local closed = tonumber(ev.match)
+    for tab, win in pairs(panel_wins) do
+      if win == closed then
+        panel_wins[tab] = nil
+      end
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd('BufDelete', {
+  group = ag,
+  desc = 'Clean up info buffer when its coq buffer is deleted',
+  callback = function(ev)
+    local info = info_bufnrs[ev.buf]
+    if info then
+      info_bufnrs[ev.buf] = nil
+      if vim.api.nvim_buf_is_valid(info) then
+        vim.api.nvim_buf_delete(info, { force = true })
+      end
+    end
+  end,
+})
+
+return M

--- a/lua/coq-lsp/render.lua
+++ b/lua/coq-lsp/render.lua
@@ -14,7 +14,7 @@ function M.Goal(i, n, goal)
   lines[#lines + 1] = 'Goal ' .. i .. ' / ' .. n
   for _, hyp in ipairs(goal.hyps) do
     local line = table.concat(hyp.names, ', ') .. ' : ' .. hyp.ty
-    if hyp.def then
+    if type(hyp.def) == 'string' then
       line = line .. ' := ' .. hyp.def
     end
     vim.list_extend(lines, vim.split(line, '\n'))

--- a/lua/coq-lsp/util.lua
+++ b/lua/coq-lsp/util.lua
@@ -6,18 +6,13 @@ local M = {}
 ---@param offset_encoding lsp.PositionEncodingKind
 ---@return APIPosition
 function M.position_lsp_to_api(bufnr, position, offset_encoding)
-  local idx = vim.lsp.util._get_line_byte_from_position(
-    bufnr,
-    { line = position.line, character = position.character },
-    offset_encoding
-  )
-  return { position.line, idx }
-end
-
-local str_utfindex = vim.fn.has('nvim-0.11') == 1 and function(s, encoding, index)
-  return vim.str_utfindex(s, encoding, index, false)
-end or function(s, encoding, index)
-  return vim.lsp.util._str_utfindex_enc(s, index, encoding)
+  local col = position.character
+  if col > 0 then
+    local line = vim.api.nvim_buf_get_lines(bufnr, position.line, position.line + 1, false)[1]
+      or ''
+    col = vim.str_byteindex(line, offset_encoding, col, false)
+  end
+  return { position.line, col }
 end
 
 ---@param bufnr buffer
@@ -32,7 +27,7 @@ function M.make_position_params(bufnr, position, offset_encoding)
     return { line = 0, character = 0 }
   end
 
-  col = str_utfindex(line, offset_encoding, col)
+  col = vim.str_utfindex(line, offset_encoding, col, false)
 
   return { line = row, character = col }
 end
@@ -47,17 +42,17 @@ function M.guess_position(bufnr)
   return vim.api.nvim_win_get_cursor(win)
 end
 
----@param client lsp.Client
+---@param client vim.lsp.Client
 ---@param bufnr integer
 ---@param method string
 ---@param params table
 ---@param handler? lsp.Handler
 ---@return fun()|nil cancel function to cancel the request
 function M.request_async(client, bufnr, method, params, handler)
-  local request_success, request_id = client.request(method, params, handler, bufnr)
+  local request_success, request_id = client:request(method, params, handler, bufnr)
   if request_success then
     return function()
-      client.cancel_request(assert(request_id))
+      client:cancel_request(assert(request_id))
     end
   end
 end


### PR DESCRIPTION
There are four commits here.

**09e9a97: updates the plugin for neovim 0.12**

This is largely a replacement of deprecated APIs, dropping support for Neovim
0.10 in the process. Work on both 0.11 and 0.12.

**82d6114 use one shared panel that retargets**

This is a feature that makes the plugin work much more like other proof
assistant plugins. Specifically, it changes the model to a one panel per tab
that retargets on focus change.

**9d7c811 fix: query goals only on focused buffer**

This is a bugfix. The plugin would error if the LSP was restarted. Basically,
register was unconditionally calling `goals_async(bufnr)` on attach, which
errored on LSP restart because on_attach fired for unfocused buffers. The fix is
to only query goals if the registered buffer is the currently focused one.

**8cef265 refactor: info panel to panel.lua, survive restart**

This is largely a refactor, but it also changes behavior. Specifically, the
panel no longer closes on LSP stop (or restart). The previous behavior meant
than an LSP restart would close and reopen the panel, which would cause the
panel to shift if you were focused on a different window. This prevents that.
