### PR TITLE
Sticky closing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ require'coq-lsp'.setup {
     --   "tab"    = one shared panel per tab, tracks the focused coq buffer.
     --   "buffer" = one panel per coq buffer.
     info_panel_mode = 'tab',
+    -- If true, a manually closed panel stays closed until you explicitly
+    -- reopen it with `:CoqLsp open_info_panel`.
+    info_panel_sticky_close = true,
   },
 
   -- The configuration forwarded to `:help lspconfig-setup`.

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -189,7 +189,7 @@ end
 function CoqLSPNvim:register(bufnr)
   assert(self.buffers[bufnr] == nil)
   self.buffers[bufnr] = {}
-  panel.open(self:panel_key(bufnr), bufnr)
+  panel.ensure_open(self:panel_key(bufnr), bufnr)
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = self.ag,

--- a/lua/coq-lsp/client.lua
+++ b/lua/coq-lsp/client.lua
@@ -189,7 +189,12 @@ end
 function CoqLSPNvim:register(bufnr)
   assert(self.buffers[bufnr] == nil)
   self.buffers[bufnr] = {}
-  panel.ensure_open(self:panel_key(bufnr), bufnr)
+  local pk = self:panel_key(bufnr)
+  if self.config.info_panel_sticky_close then
+    panel.ensure_open(pk, bufnr)
+  else
+    panel.open(pk, bufnr)
+  end
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = self.ag,

--- a/lua/coq-lsp/init.lua
+++ b/lua/coq-lsp/init.lua
@@ -4,6 +4,7 @@ local M = {}
 ---@field goals_debounce integer
 ---@field show_goals_on "manual"|"cursor"
 ---@field info_panel_mode "tab"|"buffer"
+---@field info_panel_sticky_close boolean
 
 ---@type coqlsp.config
 M.config = {
@@ -11,6 +12,7 @@ M.config = {
   show_goals_on = 'cursor',
   goals_debounce = 150,
   info_panel_mode = 'tab',
+  info_panel_sticky_close = true,
 }
 
 ---@type table<integer, CoqLSPNvim>

--- a/lua/coq-lsp/panel.lua
+++ b/lua/coq-lsp/panel.lua
@@ -2,7 +2,7 @@
 --
 -- A panel is a UI artifact tied to a coq buffer, not to an LSP client.
 --
--- `panel_wins` is keyed by an opaque "panel key" chosen by the caller —
+-- `panels` is keyed by an opaque "panel key" chosen by the caller —
 -- typically a tabpage id (one panel per tab) or a coq bufnr (one panel per
 -- buffer). The panel module doesn't care which; it just maps key -> window.
 
@@ -10,8 +10,9 @@ local M = {}
 
 ---@alias coqlsp.PanelKey integer
 
----@type table<coqlsp.PanelKey, window>
-local panel_wins = {}
+-- winid = open, false = dismissed, absent = never opened.
+---@type table<coqlsp.PanelKey, window|false>
+local panels = {}
 ---@type table<buffer, buffer> coq bufnr -> info bufnr
 local info_bufnrs = {}
 
@@ -53,7 +54,7 @@ end
 function M.open(key, bufnr)
   local info_bufnr = M.get_info_bufnr(bufnr)
 
-  local existing = panel_wins[key]
+  local existing = panels[key]
   if existing and vim.api.nvim_win_is_valid(existing) then
     vim.api.nvim_win_set_buf(existing, info_bufnr)
     return
@@ -67,8 +68,17 @@ function M.open(key, bufnr)
     mods = { keepjumps = true, keepalt = true, vertical = true, split = 'belowright' },
   }
   vim.cmd.clearjumps()
-  panel_wins[key] = vim.api.nvim_get_current_win()
+  panels[key] = vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(cur_win)
+end
+
+---Like `open`, but respects a prior manual close.
+---@param key coqlsp.PanelKey
+---@param bufnr buffer coq buffer
+function M.ensure_open(key, bufnr)
+  if panels[key] ~= false then
+    M.open(key, bufnr)
+  end
 end
 
 ---Retarget `key`'s panel (if any) to `bufnr`'s info buffer.
@@ -76,7 +86,7 @@ end
 ---@param key coqlsp.PanelKey
 ---@param bufnr buffer coq buffer
 function M.retarget(key, bufnr)
-  local win = panel_wins[key]
+  local win = panels[key]
   if not (win and vim.api.nvim_win_is_valid(win)) then
     return
   end
@@ -87,12 +97,12 @@ local ag = vim.api.nvim_create_augroup('coq-lsp-panel', { clear = true })
 
 vim.api.nvim_create_autocmd('WinClosed', {
   group = ag,
-  desc = 'Forget closed coq-lsp info panel windows',
+  desc = 'Mark coq-lsp info panel as dismissed when closed',
   callback = function(ev)
     local closed = tonumber(ev.match)
-    for key, win in pairs(panel_wins) do
+    for key, win in pairs(panels) do
       if win == closed then
-        panel_wins[key] = nil
+        panels[key] = false
       end
     end
   end,
@@ -109,6 +119,8 @@ vim.api.nvim_create_autocmd('BufDelete', {
         vim.api.nvim_buf_delete(info, { force = true })
       end
     end
+    -- Clear last: nvim_buf_delete may fire WinClosed and re-set panels[ev.buf].
+    panels[ev.buf] = nil
   end,
 })
 


### PR DESCRIPTION
Sometimes I'm just looking at Rocq and don't care about the info panel, but I still want to get diagnostics and other LSP functionality. When I'd close the info panel, it would reopen as soon as I opened another Rocq file. This fixes that by making closing "sticky" until you open the info panel again manually. I've also made the option configurable.